### PR TITLE
self type considered harmful

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -33,7 +33,7 @@ return PhpCsFixer\Config::create()
         'no_leading_import_slash' => true,
         'no_extra_consecutive_blank_lines' => ['use'],
         'blank_line_before_return' => true,
-        'self_accessor' => true,
+        'self_accessor' => false,
         'no_short_bool_cast' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'no_singleline_whitespace_before_semicolons' => true,

--- a/src/FantasyLand/Apply.php
+++ b/src/FantasyLand/Apply.php
@@ -9,7 +9,7 @@ interface Apply extends Functor
     /**
      * @param Apply $b
      *
-     * @return self
+     * @return Apply
      */
-    public function ap(self $b): self;
+    public function ap(Apply $b): Apply;
 }

--- a/src/FantasyLand/Chain.php
+++ b/src/FantasyLand/Chain.php
@@ -11,7 +11,7 @@ interface Chain extends Apply
      *
      * @param callable $function
      *
-     * @return self
+     * @return Chain
      */
     public function bind(callable $function);
 }

--- a/src/FantasyLand/Functor.php
+++ b/src/FantasyLand/Functor.php
@@ -11,7 +11,7 @@ interface Functor
      *
      * @param callable $function
      *
-     * @return self
+     * @return Functor
      */
-    public function map(callable $function): self;
+    public function map(callable $function): Functor;
 }

--- a/src/FantasyLand/Semigroup.php
+++ b/src/FantasyLand/Semigroup.php
@@ -12,5 +12,5 @@ interface Semigroup
      * @param  self $value
      * @return self
      */
-    public function concat(self $value): self;
+    public function concat(self $value): Semigroup;
 }

--- a/src/FantasyLand/Semigroup.php
+++ b/src/FantasyLand/Semigroup.php
@@ -9,8 +9,8 @@ interface Semigroup
     /**
      * Return result of applying one semigroup with another.
      *
-     * @param  self $value
-     * @return self
+     * @param  Semigroup $value
+     * @return Semigroup
      */
-    public function concat(self $value): Semigroup;
+    public function concat(Semigroup $value): Semigroup;
 }


### PR DESCRIPTION
When using interface with `self` as return i.e. `Functor` new class require reimplementing.

```php
class A implements Functor {
    public function map(callable $function): self {
    }
}
```

this code results in error
```
 Declaration of A::map(callable $function): A must be compatible with FunctionalPHP\FantasyLand\Functor::map(callable $function): FunctionalPHP\FantasyLand\Functor in (..)
```

To fix it, interface should have explicit return type
```php
class A implements Functor {
    public function map(callable $function): Functor {
    }
}
```
