### PR TITLE
Fix most Psalm/PHPStan issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /vendor/
-.php_cs.cache
+.cache/
 composer.lock

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,9 +1,10 @@
 <?php
-$finder = PhpCsFixer\Finder::create()
+$finder = (new PhpCsFixer\Finder())
     ->exclude('vendor')
     ->in(__DIR__);
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setUsingCache(true)
+    ->setCacheFile('.cache/php-cs-fixer/php-cs-fixer.cache')
     ->setRules([
         '@PSR2' => true,
         'encoding' => true,
@@ -14,7 +15,7 @@ return PhpCsFixer\Config::create()
         'indentation_type' => true,
         'blank_line_after_namespace' => true,
         'line_ending' => true,
-        'lowercase_constants' => true,
+        'constant_case' => ['case' => 'lower'],
         'lowercase_keywords' => true,
         'no_closing_tag' => true,
         'single_line_after_imports' => true,
@@ -23,7 +24,7 @@ return PhpCsFixer\Config::create()
         'whitespace_after_comma_in_array' => true,
         'blank_line_after_opening_tag' => true,
         'no_empty_statement' => true,
-        'no_extra_consecutive_blank_lines' => true,
+        'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
         'no_leading_namespace_whitespace' => true,
         'no_blank_lines_after_class_opening' => true,
@@ -31,8 +32,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_scalar' => true,
         'phpdoc_types' => true,
         'no_leading_import_slash' => true,
-        'no_extra_consecutive_blank_lines' => ['use'],
-        'blank_line_before_return' => true,
+        'blank_line_before_statement' => ['statements' => ['return']],
         'self_accessor' => false,
         'no_short_bool_cast' => true,
         'no_trailing_comma_in_singleline_array' => true,

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "test": "phpunit --no-coverage",
     "fix-code": "php-cs-fixer fix --allow-risky=yes",
     "check-code": "php-cs-fixer fix --verbose --diff --dry-run --allow-risky=yes",
-    "static-analysis": "phpstan analyse"
+    "phpstan": "phpstan analyse",
+    "psalm": "psalm"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,11 @@
     "php": ">=7.1"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2",
-    "phpunit/phpunit": "^5",
-    "giorgiosironi/eris": "^0.9"
+    "friendsofphp/php-cs-fixer": "^3.65",
+    "phpunit/phpunit": "^10.0",
+    "giorgiosironi/eris": "^1.0",
+    "phpstan/phpstan": "^2.0",
+    "vimeo/psalm": "^5.26"
   },
   "prefer-stable": true,
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
   "scripts": {
     "test": "phpunit --no-coverage",
     "fix-code": "php-cs-fixer fix --allow-risky=yes",
-    "check-code": "php-cs-fixer fix --verbose --diff --dry-run --allow-risky=yes"
+    "check-code": "php-cs-fixer fix --verbose --diff --dry-run --allow-risky=yes",
+    "static-analysis": "phpstan analyse"
   }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,31 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Unable to resolve the template type b in call to function FunctionalPHP\\FantasyLand\\applicator$#'
+			identifier: argument.templateType
+			count: 1
+			path: src/FantasyLand/Helpful/ApplicativeLaws.php
+
+		-
+			message: '#^Variable \$ap in PHPDoc tag @var does not match assigned variable \$applicatorX\.$#'
+			identifier: varTag.differentVariable
+			count: 1
+			path: src/FantasyLand/Helpful/ApplicativeLaws.php
+
+		-
+			message: '#^Parameter \#1 \$f of function FunctionalPHP\\FantasyLand\\compose expects callable\(FunctionalPHP\\FantasyLand\\Functor\<b\>\)\: FunctionalPHP\\FantasyLand\\Functor\<c\>, \(callable\(FunctionalPHP\\FantasyLand\\Functor\<b\>\)\: FunctionalPHP\\FantasyLand\\Functor\<c\>\)\|FunctionalPHP\\FantasyLand\\Functor\<c\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/FantasyLand/Helpful/FunctorLaws.php
+
+		-
+			message: '#^Parameter \#2 \$g of function FunctionalPHP\\FantasyLand\\compose expects callable\(FunctionalPHP\\FantasyLand\\Functor\<a\>\)\: FunctionalPHP\\FantasyLand\\Functor\<b\>, \(callable\(FunctionalPHP\\FantasyLand\\Functor\<a\>\)\: FunctionalPHP\\FantasyLand\\Functor\<b\>\)\|FunctionalPHP\\FantasyLand\\Functor\<b\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/FantasyLand/Helpful/FunctorLaws.php
+
+		-
+			message: '#^Parameter \#4 \$f of static method FunctionalPHP\\FantasyLand\\Helpful\\MonadLaws\:\:test\(\) expects callable\(mixed\)\: FunctionalPHP\\FantasyLand\\Monad\<b\>, callable\(a\)\: FunctionalPHP\\FantasyLand\\Useful\\Identity\<b\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/FantasyLand/Helpful/Tests/MonadLawsTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: 10
+    paths:
+        - src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,8 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: 10
+    tmpDir: .cache/phpstan
     paths:
         - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd">
-    <testsuites>
-        <testsuite name="FantasyLand/Helpful/Tests">
-            <directory>./src/FantasyLand/Helpful/Tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    cacheDirectory=".cache/phpunit"
+>
+  <testsuites>
+    <testsuite name="FantasyLand/Helpful/Tests">
+      <directory>./src/FantasyLand/Helpful/Tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+  <file src="src/FantasyLand/Helpful/FunctorLaws.php">
+    <PossiblyInvalidArgument>
+      <code><![CDATA[map($f)]]></code>
+      <code><![CDATA[map($g)]]></code>
+    </PossiblyInvalidArgument>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<psalm
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    cacheDirectory=".cache/psalm"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+    errorBaseline="psalm.baseline.xml"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+    <issueHandlers>
+        <!-- This is a stylistic preference from Psalm that we don't adhere to -->
+        <ParamNameMismatch errorLevel="suppress" />
+        <!--
+            This issue _may_ point to a valid issue, but more likely it's a
+            mismatch between what is possible to express in PHPDoc and what
+            the actual expectation is.
+
+            For example, if you have a `Maybe` monad, it will implement the
+            `bind` method with a more specific type than the `Monad` interface;
+            it will be `Maybe` instead of `Monad`. This is as expected, but
+            Psalm will complain about it because Psalm is assuming that a class
+            which implements an interface should always be subsitutable for any
+            other class which implements the same interface.
+
+            Ideally, that should be solvable with static parameter types and
+            static return types, but that doesn't seem to work as expected in
+            Psalm.
+        -->
+        <MoreSpecificImplementedParamType errorLevel="info" />
+        <!--
+            This issue is usually to do with extending a PHPUnit test class, so
+            usually a false positive. We should still report it, but at a lower
+            level so that we know to investigate all such instances.
+        -->
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <!-- Psalm is complaining about being unable to load an internal PHPUnit class -->
+        <MissingDependency errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/src/FantasyLand/Applicative.php
+++ b/src/FantasyLand/Applicative.php
@@ -6,8 +6,8 @@ namespace FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends Apply<a>
- * @template-extends Pointed<a>
+ * @extends Apply<a>
+ * @extends Pointed<a>
  */
 interface Applicative extends
     Apply,

--- a/src/FantasyLand/Apply.php
+++ b/src/FantasyLand/Apply.php
@@ -6,7 +6,7 @@ namespace FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends Functor<a>
+ * @extends Functor<a>
  */
 interface Apply extends Functor
 {

--- a/src/FantasyLand/Chain.php
+++ b/src/FantasyLand/Chain.php
@@ -6,7 +6,7 @@ namespace FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends Apply<a>
+ * @extends Apply<a>
  */
 interface Chain extends Apply
 {
@@ -14,9 +14,8 @@ interface Chain extends Apply
      * bind :: Monad m => (a -> m b) -> m b
      *
      * @template b
-     * @template f of callable(a): Chain<b>
      *
-     * @param f $function
+     * @param callable(a): Chain<b> $function
      *
      * @return Chain<b>
      */

--- a/src/FantasyLand/Foldable.php
+++ b/src/FantasyLand/Foldable.php
@@ -13,10 +13,9 @@ interface Foldable
      * reduce :: (b -> a -> b) -> b -> b
      *
      * @template b
-     * @template f of callable(b, a): b
      *
-     * @param f $function    Binary function ($accumulator, $value)
-     * @param b $accumulator Value to witch reduce
+     * @param callable(b, a): b $function    Binary function ($accumulator, $value)
+     * @param b                 $accumulator Value to witch reduce
      *
      * @return b Same type as $accumulator
      */

--- a/src/FantasyLand/Functor.php
+++ b/src/FantasyLand/Functor.php
@@ -13,9 +13,8 @@ interface Functor
      * map :: Functor f => (a -> b) -> f b
      *
      * @template b
-     * @template f of callable(a): b
      *
-     * @param f $function
+     * @param callable(a): b $function
      *
      * @return Functor<b>
      */

--- a/src/FantasyLand/Functor.php
+++ b/src/FantasyLand/Functor.php
@@ -18,5 +18,5 @@ interface Functor
      *
      * @return Functor<b>
      */
-    public function map(callable $function): Functor;
+    public function map(callable $function);
 }

--- a/src/FantasyLand/Helpful/ApplicativeLaws.php
+++ b/src/FantasyLand/Helpful/ApplicativeLaws.php
@@ -52,15 +52,7 @@ class ApplicativeLaws
         );
 
         // interchange: u <*> pure x = pure ($ x) <*> u
-        /**
-         * @var callable(callable(a): b): b $ap
-         *
-         * PHPStan has no idea how currying works and it's not able to infer
-         * the types of the singly-applied applicator() calls. As such, we'll
-         * suppress the errors here.
-         *
-         * @phpstan-ignore argument.templateType,varTag.differentVariable
-         */
+        /** @var callable(callable(a): b): b $ap */
         $applicatorX = applicator($x);
         $assertEqual(
             $u->ap($pure($x)),

--- a/src/FantasyLand/Helpful/ApplicativeLaws.php
+++ b/src/FantasyLand/Helpful/ApplicativeLaws.php
@@ -15,23 +15,28 @@ class ApplicativeLaws
     /**
      * Generic test to verify if a type obey the applicative laws.
      *
-     * @param callable    $assertEqual Asserting function (Applicative $a1, Applicative $a2, $message)
-     * @param callable    $pure        Applicative "constructor"
-     * @param Applicative $u           Applicative f => f (a -> b)
-     * @param Applicative $v           Applicative f => f (a -> b)
-     * @param Applicative $w           Applicative f => f (a -> b)
-     * @param callable    $f           (a -> b)
-     * @param mixed       $x           Value to put into a applicative
+     * @template a
+     * @template b
+     * @template c
+     * @template d
+     *
+     * @param callable                            $assertEqual Asserting function (Applicative $a1, Applicative $a2, $message)
+     * @param a                                   $x           Value to put into a applicative
+     * @param callable(mixed): Applicative<mixed> $pure        Applicative "constructor"
+     * @param Applicative<callable(a): b>         $u           Applicative f => f (a -> b)
+     * @param Applicative<callable(b): c>         $v           Applicative f => f (a -> b)
+     * @param Applicative<callable(c): d>         $w           Applicative f => f (a -> b)
+     * @param callable(a): b                      $f           (a -> b)
      */
     public static function test(
         callable $assertEqual,
+        $x,
         callable $pure,
         Applicative $u,
         Applicative $v,
         Applicative $w,
-        callable $f,
-        $x
-    ) {
+        callable $f
+    ): void {
         // identity: pure id <*> v = v
         $assertEqual(
             $pure(identity)->ap($v),
@@ -47,9 +52,19 @@ class ApplicativeLaws
         );
 
         // interchange: u <*> pure x = pure ($ x) <*> u
+        /**
+         * @var callable(callable(a): b): b $ap
+         *
+         * PHPStan has no idea how currying works and it's not able to infer
+         * the types of the singly-applied applicator() calls. As such, we'll
+         * suppress the errors here.
+         *
+         * @phpstan-ignore argument.templateType,varTag.differentVariable
+         */
+        $applicatorX = applicator($x);
         $assertEqual(
             $u->ap($pure($x)),
-            $pure(applicator($x))->ap($u),
+            $pure($applicatorX)->ap($u),
             'interchange'
         );
 

--- a/src/FantasyLand/Helpful/FunctorLaws.php
+++ b/src/FantasyLand/Helpful/FunctorLaws.php
@@ -30,7 +30,6 @@ class FunctorLaws
     ): void {
         $identity =
             /**
-             * @template a
              * @param  a $x
              * @return a
              */
@@ -48,10 +47,6 @@ class FunctorLaws
         // composition: fmap (f . g)  ==  fmap f . fmap g
         $assertEqual(
             map(compose($f, $g), $x),
-            // PHPStan has no idea how currying works and it's not able to infer
-            // the types of the singly-applied map() calls. As such, we'll
-            // suppress the error here.
-            // @phpstan-ignore argument.type,argument.type
             compose(map($f), map($g))($x),
             'composition'
         );

--- a/src/FantasyLand/Helpful/MonadLaws.php
+++ b/src/FantasyLand/Helpful/MonadLaws.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace FunctionalPHP\FantasyLand\Helpful;
 
+use FunctionalPHP\FantasyLand\Monad;
+
 use function FunctionalPHP\FantasyLand\bind;
 
 class MonadLaws
@@ -11,34 +13,55 @@ class MonadLaws
     /**
      * Generic test to verify if a type obey the monad laws.
      *
-     * @param callable $assertEqual Asserting function (Monad $m1, Monad $m2, $message)
-     * @param callable $return      Monad "constructor"
-     * @param callable $f           Monadic function
-     * @param callable $g           Monadic function
-     * @param mixed    $x           Value to put into a monad
+     * @template a
+     * @template b
+     * @template c
+     *
+     * @param callable              $assertEqual Asserting function (Monad $m1, Monad $m2, $message)
+     * @param a                     $x           Value to put into a monad
+     * @param callable(a): Monad<a> $return      Monad "constructor"
+     * @param callable(a): Monad<b> $f           Monadic function
+     * @param callable(b): Monad<c> $g           Monadic function
      */
     public static function test(
         callable $assertEqual,
+        $x,
         callable $return,
         callable $f,
-        callable $g,
-        $x
-    ) {
+        callable $g
+    ): void {
         // Make reading bellow tests easier
         $m = $return($x);
 
         // left identity: (return x) >>= f ≡ f x
-        $assertEqual(bind($f, $return($x)), $f($x), 'left identity');
+        $assertEqual(
+            bind($f, $return($x)),
+            $f($x),
+            'left identity'
+        );
 
         // right identity: m >>= return ≡ m
         $assertEqual(bind($return, $m), $m, 'right identity');
 
         // associativity: (m >>= f) >>= g ≡ m >>= ( \x -> (f x >>= g) )
-        $assertEqual(
-            bind($g, bind($f, $m)),
-            bind(function ($x) use ($f, $g) {
+
+        /** @var Monad<b> $boundF */
+        $boundF = bind($f, $m);
+        /** @var Monad<c> $boundG */
+        $boundG = bind($g, $boundF);
+        $boundFoG =
+            /**
+             * @param  a        $x
+             * @return Monad<c>
+             */
+            function ($x) use ($f, $g) {
+                /** @var Monad<c> */
                 return bind($g, $f($x));
-            }, $m),
+            };
+
+        $assertEqual(
+            $boundG,
+            bind($boundFoG, $m),
             'associativity'
         );
     }

--- a/src/FantasyLand/Helpful/MonoidLaws.php
+++ b/src/FantasyLand/Helpful/MonoidLaws.php
@@ -13,17 +13,19 @@ class MonoidLaws
     /**
      * Generic test to verify if a type obey the monodic laws.
      *
-     * @param callable $assertEqual Asserting function (Monoid $m1, Monoid $m2, $message)
-     * @param Monoid   $x
-     * @param Monoid   $y
-     * @param Monoid   $z
+     * @template a
+     *
+     * @param callable  $assertEqual Asserting function (Monoid $m1, Monoid $m2, $message)
+     * @param Monoid<a> $x
+     * @param Monoid<a> $y
+     * @param Monoid<a> $z
      */
     public static function test(
         callable $assertEqual,
         Monoid $x,
         Monoid $y,
         Monoid $z
-    ) {
+    ): void {
         $assertEqual(
             concat($x, emptyy($x)),
             $x,

--- a/src/FantasyLand/Helpful/SetoidLaws.php
+++ b/src/FantasyLand/Helpful/SetoidLaws.php
@@ -10,17 +10,21 @@ use function FunctionalPHP\FantasyLand\equal;
 class SetoidLaws
 {
     /**
-     * @param callable $assertEqual
-     * @param Setoid   $a
-     * @param Setoid   $b
-     * @param Setoid   $c
+     * @template a
+     * @template b
+     * @template c
+     *
+     * @param callable  $assertEqual
+     * @param Setoid<a> $a
+     * @param Setoid<b> $b
+     * @param Setoid<c> $c
      */
     public static function test(
         callable $assertEqual,
         Setoid $a,
         Setoid $b,
         Setoid $c
-    ) {
+    ): void {
         $assertEqual(
             equal($a, $a),
             true,

--- a/src/FantasyLand/Helpful/Tests/ApplicativeLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/ApplicativeLawsTest.php
@@ -8,7 +8,7 @@ use FunctionalPHP\FantasyLand\Applicative;
 use FunctionalPHP\FantasyLand\Helpful\ApplicativeLaws;
 use FunctionalPHP\FantasyLand\Useful\Identity;
 
-class ApplicativeLawsTest extends \PHPUnit_Framework_TestCase
+class ApplicativeLawsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideApplicativeTestData
@@ -31,23 +31,26 @@ class ApplicativeLawsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function provideApplicativeTestData()
+    /**
+     * @return array{default: array<string, mixed>}
+     */
+    public static function provideApplicativeTestData()
     {
         return [
             'default' => [
-                '$u' => Identity::of(function () {
+                'x' => 33,
+                'u' => Identity::of(function () {
                     return 1;
                 }),
-                '$v' => Identity::of(function () {
+                'v' => Identity::of(function () {
                     return 5;
                 }),
-                '$w' => Identity::of(function () {
+                'w' => Identity::of(function () {
                     return 7;
                 }),
-                '$f' => function ($x) {
+                'f' => function (int $x) {
                     return $x + 400;
-                },
-                '$x' => 33
+                }
             ],
         ];
     }

--- a/src/FantasyLand/Helpful/Tests/ApplicativeLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/ApplicativeLawsTest.php
@@ -35,7 +35,7 @@ class ApplicativeLawsTest extends \PHPUnit\Framework\TestCase
         // the `pure` function.
         $pure =
             /**
-             * @param a $x
+             * @param  a           $x
              * @return Identity<a>
              */
             function ($x) {

--- a/src/FantasyLand/Helpful/Tests/ApplicativeLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/ApplicativeLawsTest.php
@@ -12,22 +12,44 @@ class ApplicativeLawsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideApplicativeTestData
+     *
+     * @template a
+     * @template b
+     * @template c
+     * @template d
+     *
+     * @param a                           $x
+     * @param Applicative<callable(a): b> $u
+     * @param Applicative<callable(b): c> $v
+     * @param Applicative<callable(c): d> $w
+     * @param callable(a): b              $f
      */
     public function test_it_should_obey_applicative_laws(
+        $x,
         Applicative $u,
         Applicative $v,
         Applicative $w,
-        callable $f,
-        $x
-    ) {
+        callable $f
+    ): void {
+        // This is a workaround to allow static analysis to infer the types of
+        // the `pure` function.
+        $pure =
+            /**
+             * @param a $x
+             * @return Identity<a>
+             */
+            function ($x) {
+                return Identity::of($x);
+            };
+
         ApplicativeLaws::test(
             [$this, 'assertEquals'],
-            Identity::of,
+            $x,
+            $pure,
             $u,
             $v,
             $w,
-            $f,
-            $x
+            $f
         );
     }
 

--- a/src/FantasyLand/Helpful/Tests/FunctorLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/FunctorLawsTest.php
@@ -8,7 +8,7 @@ use FunctionalPHP\FantasyLand\Functor;
 use FunctionalPHP\FantasyLand\Helpful\FunctorLaws;
 use FunctionalPHP\FantasyLand\Useful\Identity;
 
-class FunctorLawsTest extends \PHPUnit_Framework_TestCase
+class FunctorLawsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideFunctorTestData
@@ -26,17 +26,20 @@ class FunctorLawsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function provideFunctorTestData()
+    /**
+     * @return array{Identity: array<string, mixed>}
+     */
+    public static function provideFunctorTestData(): array
     {
         return [
             'Identity' => [
-                '$f' => function ($x) {
+                'f' => function (int $x) {
                     return $x + 1;
                 },
-                '$g' => function ($x) {
+                'g' => function (int $x) {
                     return $x + 5;
                 },
-                '$x' => Identity::of(123),
+                'x' => Identity::of(123),
             ],
         ];
     }

--- a/src/FantasyLand/Helpful/Tests/FunctorLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/FunctorLawsTest.php
@@ -12,12 +12,20 @@ class FunctorLawsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideFunctorTestData
+     *
+     * @template a
+     * @template b
+     * @template c
+     *
+     * @param callable(b): c $f
+     * @param callable(a): b $g
+     * @param Functor<a>     $x
      */
     public function test_it_should_obey_functor_laws(
         callable $f,
         callable $g,
         Functor $x
-    ) {
+    ): void {
         FunctorLaws::test(
             [$this, 'assertEquals'],
             $f,

--- a/src/FantasyLand/Helpful/Tests/MonadLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/MonadLawsTest.php
@@ -26,7 +26,7 @@ class MonadLawsTest extends \PHPUnit\Framework\TestCase
         // the `pure` function.
         $pure =
             /**
-             * @param a $x
+             * @param  a           $x
              * @return Identity<a>
              */
             function ($x) {
@@ -37,10 +37,6 @@ class MonadLawsTest extends \PHPUnit\Framework\TestCase
             [$this, 'assertEquals'],
             $x,
             $pure,
-            // PHPStan seems to have lost track of `a` here, and is unable to
-            // infer that `$f` should be callable(a): Identity<b>. It seems to
-            // have inferred that `$f` is callable(mixed): Identity<b>.
-            // @phpstan-ignore argument.type
             $f,
             $g
         );
@@ -51,10 +47,10 @@ class MonadLawsTest extends \PHPUnit\Framework\TestCase
      */
     public static function provideData(): array
     {
-        $addOne = function (int $x) {
+        $addOne = function (int $x): Identity {
             return Identity::of($x + 1);
         };
-        $addTwo = function (int $x) {
+        $addTwo = function (int $x): Identity {
             return Identity::of($x + 2);
         };
 

--- a/src/FantasyLand/Helpful/Tests/MonadLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/MonadLawsTest.php
@@ -7,7 +7,7 @@ namespace FunctionalPHP\FantasyLand\Helpful\Tests;
 use FunctionalPHP\FantasyLand\Helpful\MonadLaws;
 use FunctionalPHP\FantasyLand\Useful\Identity;
 
-class MonadLawsTest extends \PHPUnit_Framework_TestCase
+class MonadLawsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider provideData
@@ -23,7 +23,10 @@ class MonadLawsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function provideData()
+    /**
+     * @return array{Identity: array<string, mixed>}
+     */
+    public static function provideData(): array
     {
         $addOne = function ($x) {
             return Identity::of($x + 1);
@@ -34,9 +37,9 @@ class MonadLawsTest extends \PHPUnit_Framework_TestCase
 
         return [
             'Identity' => [
-                '$f' => $addOne,
-                '$g' => $addTwo,
-                '$x' => 10,
+                'x' => 10,
+                'f' => $addOne,
+                'g' => $addTwo,
             ],
         ];
     }

--- a/src/FantasyLand/Helpful/Tests/StringMonoidLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/StringMonoidLawsTest.php
@@ -9,6 +9,8 @@ use Eris\TestTrait;
 use FunctionalPHP\FantasyLand\Helpful\MonoidLaws;
 use FunctionalPHP\FantasyLand\Monoid;
 use FunctionalPHP\FantasyLand\Semigroup;
+use function FunctionalPHP\FantasyLand\concat;
+use function FunctionalPHP\FantasyLand\emptyy;
 
 class StringMonoid implements Monoid
 {
@@ -39,6 +41,14 @@ class StringMonoid implements Monoid
     }
 }
 
+/**
+ * This class is not a monoid because it does not obey the monoid laws,
+ * despite implementing the Monoid interface. In particular, it does not obay
+ * the right identity and left identity laws, due to the way the `mempty` method
+ * is implemented.
+ *
+ * @implements Monoid<string>
+ */
 class NotAStringMonoid implements Monoid
 {
     /**
@@ -68,7 +78,7 @@ class NotAStringMonoid implements Monoid
     }
 }
 
-class StringMonoidLawsTest extends \PHPUnit_Framework_TestCase
+class StringMonoidLawsTest extends \PHPUnit\Framework\TestCase
 {
     use TestTrait;
 
@@ -98,11 +108,26 @@ class StringMonoidLawsTest extends \PHPUnit_Framework_TestCase
             Generator\string(),
             Generator\names()
         )->then(function (string $a, string $b, string $c) {
-            MonoidLaws::test(
-                [$this, 'assertEquals'],
-                new NotAStringMonoid($a),
-                new NotAStringMonoid($b),
-                new NotAStringMonoid($c)
+            $x = new NotAStringMonoid($a);
+            $y = new NotAStringMonoid($b);
+            $z = new NotAStringMonoid($c);
+
+            $this->assertNotEquals(
+                concat($x, emptyy($x)),
+                $x,
+                'Right identity'
+            );
+
+            $this->assertNotEquals(
+                concat(emptyy($x), $x),
+                $x,
+                'Left identity'
+            );
+
+            $this->assertEquals(
+                concat($x, concat($y, $z)),
+                concat(concat($x, $y), $z),
+                'Associativity'
             );
         });
     }

--- a/src/FantasyLand/Helpful/Tests/StringMonoidLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/StringMonoidLawsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FunctionalPHP\FantasyLand\Helpful\Tests;
 
-use Eris\Generator;
+use Eris\Generators;
 use Eris\TestTrait;
 use FunctionalPHP\FantasyLand\Helpful\MonoidLaws;
 use FunctionalPHP\FantasyLand\Monoid;
@@ -12,6 +12,11 @@ use FunctionalPHP\FantasyLand\Semigroup;
 use function FunctionalPHP\FantasyLand\concat;
 use function FunctionalPHP\FantasyLand\emptyy;
 
+/**
+ * This class is a monoid because it obeys the monoid laws.
+ *
+ * @implements Monoid<string>
+ */
 class StringMonoid implements Monoid
 {
     /**
@@ -26,6 +31,7 @@ class StringMonoid implements Monoid
 
     /**
      * @inheritdoc
+     * @return StringMonoid
      */
     public static function mempty()
     {
@@ -34,6 +40,8 @@ class StringMonoid implements Monoid
 
     /**
      * @inheritdoc
+     * @param  StringMonoid $value
+     * @return StringMonoid
      */
     public function concat(Semigroup $value): Semigroup
     {
@@ -63,6 +71,7 @@ class NotAStringMonoid implements Monoid
 
     /**
      * @inheritdoc
+     * @return NotAStringMonoid
      */
     public static function mempty()
     {
@@ -71,6 +80,8 @@ class NotAStringMonoid implements Monoid
 
     /**
      * @inheritdoc
+     * @param  NotAStringMonoid $value
+     * @return NotAStringMonoid
      */
     public function concat(Semigroup $value): Semigroup
     {
@@ -82,12 +93,12 @@ class StringMonoidLawsTest extends \PHPUnit\Framework\TestCase
 {
     use TestTrait;
 
-    public function test_it_should_obay_monoid_laws()
+    public function test_it_should_obay_monoid_laws(): void
     {
         $this->forAll(
-            Generator\char(),
-            Generator\string(),
-            Generator\names()
+            Generators::char(),
+            Generators::string(),
+            Generators::names()
         )->then(function (string $a, string $b, string $c) {
             MonoidLaws::test(
                 [$this, 'assertEquals'],
@@ -98,15 +109,12 @@ class StringMonoidLawsTest extends \PHPUnit\Framework\TestCase
         });
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function test_it_should_fail_monoid_laws()
+    public function test_it_should_fail_monoid_laws(): void
     {
         $this->forAll(
-            Generator\char(),
-            Generator\string(),
-            Generator\names()
+            Generators::char(),
+            Generators::string(),
+            Generators::names()
         )->then(function (string $a, string $b, string $c) {
             $x = new NotAStringMonoid($a);
             $y = new NotAStringMonoid($b);

--- a/src/FantasyLand/Helpful/Tests/StringSetoidLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/StringSetoidLawsTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace FunctionalPHP\FantasyLand\Helpful\Tests;
 
-use Eris\Generator;
+use Eris\Generators;
 use Eris\TestTrait;
 use FunctionalPHP\FantasyLand\Helpful\SetoidLaws;
 use FunctionalPHP\FantasyLand\Setoid;
 
+/**
+ * @implements Setoid<string>
+ */
 class StringSetoid implements Setoid
 {
     /**
@@ -36,12 +39,12 @@ class StringSetoidLawsTest extends \PHPUnit\Framework\TestCase
 {
     use TestTrait;
 
-    public function test_it_should_obay_setoid_laws()
+    public function test_it_should_obay_setoid_laws(): void
     {
         $this->forAll(
-            Generator\char(),
-            Generator\string(),
-            Generator\names()
+            Generators::char(),
+            Generators::string(),
+            Generators::names()
         )->then(function (string $a, string $b, string $c) {
             SetoidLaws::test(
                 [$this, 'assertEquals'],

--- a/src/FantasyLand/Helpful/Tests/StringSetoidLawsTest.php
+++ b/src/FantasyLand/Helpful/Tests/StringSetoidLawsTest.php
@@ -32,7 +32,7 @@ class StringSetoid implements Setoid
     }
 }
 
-class StringSetoidLawsTest extends \PHPUnit_Framework_TestCase
+class StringSetoidLawsTest extends \PHPUnit\Framework\TestCase
 {
     use TestTrait;
 

--- a/src/FantasyLand/Monad.php
+++ b/src/FantasyLand/Monad.php
@@ -6,8 +6,8 @@ namespace FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends Applicative<a>
- * @template-extends Chain<a>
+ * @extends Applicative<a>
+ * @extends Chain<a>
  */
 interface Monad extends
     Applicative,

--- a/src/FantasyLand/Monoid.php
+++ b/src/FantasyLand/Monoid.php
@@ -6,7 +6,7 @@ namespace FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends Semigroup<a>
+ * @extends Semigroup<a>
  */
 interface Monoid extends Semigroup
 {

--- a/src/FantasyLand/Pointed.php
+++ b/src/FantasyLand/Pointed.php
@@ -12,9 +12,11 @@ interface Pointed
     /**
      * Put $value in default minimal context.
      *
-     * @param a $value
+     * @template A
      *
-     * @return Pointed<a>
+     * @param A $value
+     *
+     * @return Pointed<A>
      */
     public static function of($value);
 }

--- a/src/FantasyLand/Setoid.php
+++ b/src/FantasyLand/Setoid.php
@@ -12,7 +12,7 @@ interface Setoid
     /**
      * @template b
      *
-     * @param Setoid<b>|mixed $other
+     * @param Setoid<b> $other
      *
      * @return bool
      */

--- a/src/FantasyLand/Traversable.php
+++ b/src/FantasyLand/Traversable.php
@@ -6,7 +6,7 @@ namespace FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends Functor<a>
+ * @extends Functor<a>
  */
 interface Traversable extends Functor
 {
@@ -16,9 +16,8 @@ interface Traversable extends Functor
      * Where the `a` is value inside of container.
      *
      * @template b
-     * @template fn of callable(a): Applicative<b>
      *
-     * @param fn $fn (a -> f b)
+     * @param callable(a): Applicative<b> $fn (a -> f b)
      *
      * @return Applicative<Traversable<b>> f (t b)
      */

--- a/src/FantasyLand/Useful/Identity.php
+++ b/src/FantasyLand/Useful/Identity.php
@@ -8,25 +8,31 @@ use FunctionalPHP\FantasyLand;
 
 /**
  * @template a
- * @template-extends FantasyLand\Monad<a>
+ * @implements FantasyLand\Monad<a>
  */
 class Identity implements FantasyLand\Monad
 {
     public const of = 'FunctionalPHP\FantasyLand\Useful\Identity::of';
 
     /**
-     * @var mixed
+     * @var a
      */
     private $value;
 
     /**
      * @inheritdoc
+     * @template A
+     * @param A $value
+     * @return Identity<A>
      */
     public static function of($value)
     {
-        return new self($value);
+        return new Identity($value);
     }
 
+    /**
+     * @param a $value
+     */
     private function __construct($value)
     {
         $this->value = $value;
@@ -34,18 +40,60 @@ class Identity implements FantasyLand\Monad
 
     /**
      * @inheritdoc
+     * @template b
+     * @param  callable(a): b $transformation
+     * @return Identity<b>
      */
-    public function map(callable $transformation): FantasyLand\Functor
+    public function map(callable $transformation): Identity
     {
-        return static::of($this->bind($transformation));
+        /**
+         * This is a workaround so that static analysis tools can understand
+         * the type signature of the callables.
+         *
+         * @param  a           $x
+         * @return Identity<b>
+         */
+        $fn = static function ($x) use ($transformation) {
+            return Identity::of($transformation($x));
+        };
+
+        /** @var Identity<b> */
+        return $this->bind($fn);
     }
 
     /**
      * @inheritdoc
+     *
+     * TODO: Not sure how to write the type signature for this method; it seems
+     *       to rely on the current `a` type being a subtype of `callable(b): c`
+     *       which cannot be guaranteed by the type system as this may have been
+     *       instantiated with any type. Calling `->ap(...)` on an instance of
+     *       `Identity` with a non-callable value will result in a runtime error
+     *       that cannot be caught by the type system. Additionally, if the
+     *       `Identity` instance has a callable value, we still cannot guarentee
+     *       that the types line up correctly, so really anything could happen
+     *       here.
+     *
+     * @template b
+     * @param  Identity<b>           $applicative
+     * @return Identity<mixed>|never
      */
     public function ap(FantasyLand\Apply $applicative): FantasyLand\Apply
     {
-        return $applicative->map($this->value);
+        $value = $this->value;
+
+        if (!is_callable($value)) {
+            throw new \TypeError('Cannot call `ap` on an Identity instance with a non-callable value');
+        }
+
+        /**
+         * Being optimistic and hoping that _if_ $value is callable then the
+         * types should line up correctly (assuming the user of the function
+         * hasn't provided a callable of a different type).
+         *
+         * @var callable(b): mixed $value
+         */
+        return $applicative->map($value);
     }
 
     /**

--- a/src/FantasyLand/Useful/Identity.php
+++ b/src/FantasyLand/Useful/Identity.php
@@ -22,7 +22,7 @@ class Identity implements FantasyLand\Monad
     /**
      * @inheritdoc
      * @template A
-     * @param A $value
+     * @param  A           $value
      * @return Identity<A>
      */
     public static function of($value)
@@ -46,16 +46,17 @@ class Identity implements FantasyLand\Monad
      */
     public function map(callable $transformation): Identity
     {
-        /**
-         * This is a workaround so that static analysis tools can understand
-         * the type signature of the callables.
-         *
-         * @param  a           $x
-         * @return Identity<b>
-         */
-        $fn = static function ($x) use ($transformation) {
-            return Identity::of($transformation($x));
-        };
+        $fn =
+            /**
+             * This is a workaround so that static analysis tools can understand
+             * the type signature of the callables.
+             *
+             * @param  a           $x
+             * @return Identity<b>
+             */
+            static function ($x) use ($transformation): Identity {
+                return Identity::of($transformation($x));
+            };
 
         /** @var Identity<b> */
         return $this->bind($fn);

--- a/src/FantasyLand/Useful/Identity.php
+++ b/src/FantasyLand/Useful/Identity.php
@@ -12,7 +12,7 @@ use FunctionalPHP\FantasyLand;
  */
 class Identity implements FantasyLand\Monad
 {
-    const of = 'FunctionalPHP\FantasyLand\Useful\Identity::of';
+    public const of = 'FunctionalPHP\FantasyLand\Useful\Identity::of';
 
     /**
      * @var mixed

--- a/src/FantasyLand/functions.php
+++ b/src/FantasyLand/functions.php
@@ -73,19 +73,18 @@ const map = 'FunctionalPHP\FantasyLand\map';
  *
  * @template a
  * @template b
- * @template f of callable(a): b
- * @template next of callable(Functor<a>): Functor<b>
  *
- * @param f               $transformation
+ * @param callable(a): b  $transformation
  * @param Functor<a>|null $value
  *
- * @return Functor<b>|next If a functor was provided directly to map, returns
- *                         the result of applying the transformation to the
- *                         value. Otherwise, returns a curried function that
- *                         expects a functor.
+ * @return Functor<b>|(callable(Functor<a>): Functor<b>)
+ *                                                       If a functor was provided directly to map, returns the result of
+ *                                                       applying the transformation to the value. Otherwise, returns a curried
+ *                                                       function that expects a functor.
  */
 function map(callable $transformation, ?Functor $value = null)
 {
+    /** @var Functor<b>|(callable(Functor<a>): Functor<b>) */
     return curryN(2, function (callable $transformation, Functor $value) {
         return $value->map($transformation);
     })(...func_get_args());
@@ -101,19 +100,22 @@ const bind = 'FunctionalPHP\FantasyLand\bind';
  *
  * @template a
  * @template b
- * @template f of callable(a): Monad<b>
- * @template next of callable(Monad<a>): Monad<b>
  *
- * @param f             $function
- * @param Monad<a>|null $value
+ * @param callable(a): Monad<b> $function
+ * @param Monad<a>|null         $value
  *
- * @return Monad<b>|next If a monad was provided directly to bind, returns the
- *                       result. Otherwise, returns a curried function that
- *                       expects a monad.
+ * @return Monad<b>|(callable(Monad<a>): Monad<b>)
+ *                                                 If a monad was provided directly to bind, returns the result. Otherwise,
+ *                                                 returns a curried function that expects a monad.
  */
 function bind(callable $function, ?Monad $value = null)
 {
+    /** @var Monad<b>|(callable(Monad<a>): Monad<b>) */
     return curryN(2, function (callable $function, Monad $value) {
+        /**
+         * @var callable(a): Monad<b> $function
+         * @var Monad<a>              $value
+         */
         return $value->bind($function);
     })(...func_get_args());
 }
@@ -127,13 +129,10 @@ const compose = 'FunctionalPHP\FantasyLand\compose';
  * @template a
  * @template b
  * @template c
- * @template f of callable(b): c
- * @template g of callable(a): b
- * @template composed of callable(a): c
  *
- * @param  f        $f
- * @param  g        $g
- * @return composed
+ * @param  callable(b): c $f
+ * @param  callable(a): b $g
+ * @return callable(a): c
  */
 function compose(callable $f, callable $g): callable
 {
@@ -152,15 +151,14 @@ const applicator = 'FunctionalPHP\FantasyLand\applicator';
  *
  * @template a
  * @template b
- * @template f of callable(a): b
- * @template next of callable(f): b
  *
- * @param a      $x
- * @param f|null $f
+ * @param a                   $x
+ * @param callable(a): b|null $f
  *
- * @return b|next If a function was provided directly to applicator, returns the
- *                result of applying the function to the value. Otherwise,
- *                returns a curried function that expects said function.
+ * @return b|(callable(callable(a): b): b)
+ *                                         If a function was provided directly to applicator, returns the result of
+ *                                         applying the function to the value. Otherwise, returns a curried
+ *                                         function that expects said function.
  */
 function applicator($x, ?callable $f = null)
 {
@@ -174,7 +172,7 @@ function applicator($x, ?callable $f = null)
  *
  * @param int      $numberOfArguments
  * @param callable $function
- * @param array    $args
+ * @param mixed[]  $args
  *
  * @return callable
  */

--- a/src/FantasyLand/functions.php
+++ b/src/FantasyLand/functions.php
@@ -63,7 +63,6 @@ function emptyy(Monoid $a): Monoid
     return $a::mempty();
 }
 
-
 /**
  * @var callable
  */
@@ -143,7 +142,6 @@ function compose(callable $f, callable $g): callable
     };
 }
 
-
 /**
  * @var callable
  */
@@ -170,7 +168,6 @@ function applicator($x, ?callable $f = null)
         return $f($x);
     })(...func_get_args());
 }
-
 
 /**
  * Curry function


### PR DESCRIPTION
This MR does a few things:

1. Updates the require-dev dependencies to allow users running PHP 8+ to run tests and static analysis
2. Adds Psalm and PHPStan as dev dependencies to the project.
3. Fixes many of the Psalm/PHPStan issues noted in #22.

Looking at the primary complaints in #22, it appears that mostly these had to do with PHPStan not accepting bound template types in the PHPDoc comments. This would be something along the lines of

```php
/**
 * @template a
 * @template b
 * @template f of callable(a): b
 */
```

where `f` is a bound template, as it is defined in terms of the bound type terms `a` and `b`. Again, PHPStan does not currently support this.

I also noted a couple of other issues with the types presented which required more than just documentation fixes, so I decided to ensure I was running the unit tests to ensure I didn't break anything. This required me to update the version of PHPUnit in the project, as I only have recent versions of PHP installed and the version in the project did not run in recent versions of PHP. This in turn also required updates to php-cs-fixer and eris.

Once I had that all updated, I installed PHPStan and Psalm as dev dependencies so they could be run against the project to ensure that everything worked properly.

I did discover a few points where either (or neither) PHPStan or Psalm could not correctly deduce what was going on; for example, anything to do with the `curryN` function immediately becomes super difficult for static analysis to follow. For these issues, I've added them to the respective baseline error files so that anyone who wants to have a crack at getting Psalm/PHPStan to understand what's going on can do so, without having these tools display errors where there aren't any.

I've also corralled all of the respective cache files/directories into a single ignored `/.cache` directory, simply to keep things centralized but not in the root of the project getting in everyone's way.